### PR TITLE
Add project artifactId override ability for project bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gradle-karaf-features-plugin
 
 How to use
 ============================
-build.gradle  
+build.gradle
 ```
 buildscript {
   repositories {
@@ -11,6 +11,22 @@ buildscript {
   }
   dependencies {
     classpath 'com.github.lburgazzoli:gradle-karaf-features-plugin:2.7.0'
+  }
+}
+
+group = 'com.github'
+version = '1.0.0'
+//name is 'project1'
+
+project(':subproject1') {
+  dependencies {
+    compile 'commons-lang:commons-lang:2.6'
+  }
+}
+
+project(':subproject1') {
+  dependencies {
+    compile 'commons-io:commons-io:2.4'
   }
 }
 
@@ -42,4 +58,20 @@ karafFeatures {
 To generate feature just run  
 ```
 gradle generateKarafFeatures
+```
+
+generated file 'build/karafFeatures/project1-1.0.0-karaf.xml' will look like below  
+```xml
+<features xmlns='http://karaf.apache.org/xmlns/features/v1.2.0' name='featuresName'>
+  <repository>mvn:group/dependent-feature/1.2.3/xml/features</repository>
+  <feature name='main-feature-name' description='Some useful description' version='1.0.0'>
+    <feature>dependent-feature</feature>
+    <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
+    <bundle>mvn:com.github/subproject1/1.0.0</bundle>
+    <bundle>mvn:com.github/newSubProject2/1.0.0</bundle>
+  </feature>
+  <feature name='test-feature-name' description='Another useful description' version='1.0.0'>
+    <feature>main-feature-name</feature>
+  </feature>
+</features>
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ project(':subproject1') {
   }
 }
 
-project(':subproject1') {
+project(':subproject2') {
   dependencies {
     compile 'commons-io:commons-io:2.4'
   }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ karafFeatures {
         dependencies {
           transitive = false //true by default
         }
+        artifactId = "newSubProject2" // project name by default
       }
     }
     testFeature {

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/BundleDefinitionCalculatorObrImpl.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/BundleDefinitionCalculatorObrImpl.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 
 import com.github.lburgazzoli.gradle.plugin.karaf.features.model.BundleInstructionDescriptor
 import com.github.lburgazzoli.gradle.plugin.karaf.features.model.FeatureDescriptor
@@ -82,7 +83,7 @@ class BundleDefinitionCalculatorObrImpl implements BundleDefinitionCalculator {
 		}
 
 		// add dependencies first
-		if ( !projectDescriptor.excludeTransitiveDependecies ) {
+		if ( projectDescriptor.dependencies.transitive ) {
 			for ( DependencyResult dependency : root.dependencies ) {
 				if ( dependency instanceof UnresolvedDependencyResult ) {
 					continue;
@@ -98,7 +99,14 @@ class BundleDefinitionCalculatorObrImpl implements BundleDefinitionCalculator {
 		
 
 		// then add the root one
-		moduleVersionIdentifiers.add( root.moduleVersion )
+		ModuleVersionIdentifier rootModuleVersion = root.moduleVersion
+		String artifactId = projectDescriptor.artifactId ?: rootModuleVersion.name
+		ModuleVersionIdentifier projectModuleVersion = new DefaultModuleVersionIdentifier(
+			"${rootModuleVersion.group}",
+			"${artifactId}",
+			"${rootModuleVersion.version}"
+		)
+		moduleVersionIdentifiers.add( projectModuleVersion )
 	}
 
 	static BundleInstructionDescriptor findBundleInstructions(ModuleVersionIdentifier dep, FeatureDescriptor feature) {

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/model/ProjectDescriptor.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/model/ProjectDescriptor.groovy
@@ -46,6 +46,11 @@ class ProjectDescriptor {
 	 */
 	def ProjectDependenciesDescriptor dependenciesDescriptor
 
+	/**
+	 * Property to override project.name while feature geeration
+	 */
+	def String artifactId
+
 	ProjectDescriptor(Project project) {
 		this.project = project
 		this.dependenciesDescriptor = new ProjectDependenciesDescriptor()

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesSpec.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesSpec.groovy
@@ -19,10 +19,11 @@ import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.result.ResolvedComponentResult
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.testfixtures.ProjectBuilder
 
@@ -90,8 +91,9 @@ class KarafFeaturesSpec extends Specification {
             BundleDefinitionCalculatorMvnImpl.hasOsgiManifestHeaders() >> true
             BundleDefinitionCalculatorMvnImpl.collectDependencies(_, _, _, _, _, _) >> {feature, orderedDependencyMap, resolvedArtifactMap, configuration, extension, includeRoot ->
                 def mv = new DefaultModuleVersionIdentifier(subProject.group, subProject.name, subProject.version)
-                def result = Mock(ResolvedComponentResult);
+                def result = Mock(ResolvedComponentResult)
                 result.getModuleVersion() >> mv
+                result.getSelectionReason() >> Mock(ComponentSelectionReason)
                 orderedDependencyMap.put(mv, result)
             }
             BundleDefinitionCalculatorMvnImpl.baseMvnUrl(_) >> 'mvn:test.pkg/sub1/1.2.3'


### PR DESCRIPTION
In maven-publish plugin we have artifactId option. Since karaf features working directly with maven we need ability to set the same artifactId in project bundles
I've added this parameter to DSL and bundle calculators