### PR TITLE
Filter empty project dependency in feature

### DIFF
--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/impl/BundleDefinitionCalculatorMvnImpl.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/impl/BundleDefinitionCalculatorMvnImpl.groovy
@@ -112,9 +112,13 @@ public class BundleDefinitionCalculatorMvnImpl implements BundleDefinitionCalcul
 
                 bundleDescriptor.dependency = bundleInstruction.dependency
                 bundleDescriptor.startLevel = bundleInstruction.startLevel
+            } else if (bundleDescriptor && bundleDescriptor.path && !bundleDescriptor.path.exists()) {
+                return null;
             }
 
             return renderUrl(bundleDescriptor, bundleInstruction)
+        }.findAll {
+            it != null
         }
 	}
 


### PR DESCRIPTION
It fixes one of my cases where there are no projects in feature and by default current project comes into play.
And in my example I have no any jar in current project, so some filtering added
It would be really cool if you release new version

Thanks in advance